### PR TITLE
Admin Integration

### DIFF
--- a/django_twilio_sms/__init__.py
+++ b/django_twilio_sms/__init__.py
@@ -1,1 +1,3 @@
 __version__ = '1.0.0'
+
+default_app_config = 'django_twilio_sms.apps.DjangoTwilioSmsConfig'

--- a/django_twilio_sms/admin.py
+++ b/django_twilio_sms/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from .models import *
+
+
+admin.site.register(Message)
+admin.site.register(Response)
+admin.site.register(Account)

--- a/django_twilio_sms/admin.py
+++ b/django_twilio_sms/admin.py
@@ -2,6 +2,25 @@ from django.contrib import admin
 from .models import *
 
 
-admin.site.register(Message)
-admin.site.register(Response)
-admin.site.register(Account)
+class MessageAdmin(admin.ModelAdmin):
+    list_display = ('to_phone_number', 'from_phone_number', 'status', 'date_sent')
+    list_display_links = list_display
+    list_filter = ('status', 'date_sent')
+    date_hierarchy = 'date_sent'
+    ordering = ('-date_sent', )
+
+
+class ResponseAdmin(admin.ModelAdmin):
+    list_display = ('action', 'active', 'body', 'date_updated')
+    list_display_links = list_display
+    list_filter = ('action', 'active')
+
+
+class AccountAdmin(admin.ModelAdmin):
+    list_display = ('friendly_name', 'owner_account_sid', 'account_type', 'status', 'date_updated')
+    list_display_links = list_display
+
+
+admin.site.register(Message, MessageAdmin)
+admin.site.register(Response, ResponseAdmin)
+admin.site.register(Account, AccountAdmin)

--- a/django_twilio_sms/admin.py
+++ b/django_twilio_sms/admin.py
@@ -3,9 +3,9 @@ from .models import *
 
 
 class MessageAdmin(admin.ModelAdmin):
-    list_display = ('to_phone_number', 'from_phone_number', 'status', 'date_sent')
+    list_display = ('to_phone_number', 'from_phone_number', 'status', 'direction', 'date_sent')
     list_display_links = list_display
-    list_filter = ('status', 'date_sent')
+    list_filter = ('status', 'direction', 'date_sent')
     date_hierarchy = 'date_sent'
     ordering = ('-date_sent', )
 

--- a/django_twilio_sms/apps.py
+++ b/django_twilio_sms/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class DjangoTwilioSmsConfig(AppConfig):
+    name = 'django_twilio_sms'
+    verbose_name = _("Django Twilio SMS")


### PR DESCRIPTION
This patch adds basic admin configuration. Key attributes of Message, Account, and Response models are exposed in list views and there is some filtering. It's by no means a detailed config, just a start to build from.

Also  added an AppConfig to customize the app name within the admin site.

![admin dashboard](https://cloud.githubusercontent.com/assets/82215/14578658/45131540-0353-11e6-86ce-a8cea7897461.png)

![message list in admin](https://cloud.githubusercontent.com/assets/82215/14578655/31549786-0353-11e6-8081-578fb1e39ac3.png)
