### PR TITLE
Handle unsubscribed PhoneNumber

### DIFF
--- a/django_twilio_sms/migrations/0002_auto_20160512_2117.py
+++ b/django_twilio_sms/migrations/0002_auto_20160512_2117.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/django_twilio_sms/migrations/0002_auto_20160512_2117.py
+++ b/django_twilio_sms/migrations/0002_auto_20160512_2117.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_twilio_sms', '0001_squashed_0005_auto_20160410_1948'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='phonenumber',
+            old_name='twilio_number',
+            new_name='unsubscribed',
+        ),
+    ]

--- a/django_twilio_sms/models.py
+++ b/django_twilio_sms/models.py
@@ -189,6 +189,14 @@ class PhoneNumber(CreatedUpdated):
     def as_e164(self):
         return self.caller.phone_number.as_e164
 
+    def subscribe(self):
+        self.unsubscribed = False
+        self.save()
+
+    def unsubscribe(self):
+        self.unsubscribed = True
+        self.save()
+
 
 class Message(Sid):
 

--- a/django_twilio_sms/models.py
+++ b/django_twilio_sms/models.py
@@ -306,15 +306,16 @@ class Message(Sid):
 
     def send_response_message(self):
         if self.direction is self.INBOUND:
-            action = Action.get_action(self.body)
-            Message.send_message(
-                body=action.get_active_response().body,
-                to=self.from_phone_number,
-                from_=self.to_phone_number
-            )
-            response_message.send_robust(
-                sender=self.__class__, action=action, message=self
-            )
+            if not self.from_phone_number.unsubscribed:
+                action = Action.get_action(self.body)
+                Message.send_message(
+                    body=action.get_active_response().body,
+                    to=self.from_phone_number,
+                    from_=self.to_phone_number
+                )
+                response_message.send_robust(
+                    sender=self.__class__, action=action, message=self
+                )
 
     def sync_twilio_message(self, message=None):
         if not message:

--- a/django_twilio_sms/models.py
+++ b/django_twilio_sms/models.py
@@ -166,13 +166,13 @@ class MessagingService(Sid):
 @python_2_unicode_compatible
 class PhoneNumber(CreatedUpdated):
     caller = models.OneToOneField(Caller)
-    twilio_number = models.BooleanField(default=False)
+    unsubscribed = models.BooleanField(default=False)
 
     def __str__(self):
         return '{}'.format(self.caller.phone_number)
 
     @classmethod
-    def get_or_create(cls, phone_number, twilio_number=False):
+    def get_or_create(cls, phone_number, unsubscribed=False):
         if isinstance(phone_number, cls):
             return phone_number
 
@@ -180,7 +180,7 @@ class PhoneNumber(CreatedUpdated):
             phone_number=phone_number
         )
         phone_number_obj, create = cls.objects.get_or_create(
-            caller=caller, defaults={'twilio_number': twilio_number}
+            caller=caller, defaults={'unsubscribed': unsubscribed}
         )
 
         return phone_number_obj
@@ -347,14 +347,8 @@ class Message(Sid):
         self.currency = Currency.get_or_create(message.price_unit)
         self.api_version = ApiVersion.get_or_create(message.api_version)
 
-        if self.direction == self.INBOUND:
-            self.from_phone_number = PhoneNumber.get_or_create(message.from_)
-            self.to_phone_number = PhoneNumber.get_or_create(message.to, True)
-        else:
-            self.from_phone_number = PhoneNumber.get_or_create(
-                message.from_, True
-            )
-            self.to_phone_number = PhoneNumber.get_or_create(message.to)
+        self.from_phone_number = PhoneNumber.get_or_create(message.from_)
+        self.to_phone_number = PhoneNumber.get_or_create(message.to)
 
         self.save()
 

--- a/django_twilio_sms/models.py
+++ b/django_twilio_sms/models.py
@@ -11,7 +11,7 @@ from django_twilio.client import twilio_client
 from django_twilio.models import Caller
 from twilio.rest.exceptions import TwilioRestException
 
-from .signals import response_message
+from .signals import response_message, unsubscribe_signal
 from .utils import AbsoluteURI
 
 
@@ -323,8 +323,17 @@ class Message(Sid):
 
         if body in self.UNSUBSCRIBE_MESSAGES:
             self.from_phone_number.unsubscribe()
+
+            unsubscribe_signal.send_robust(
+                sender=self.__class__, message=self, unsubscribed=True
+            )
+
         elif body in self.SUBSCRIBE_MESSAGES:
             self.from_phone_number.subscribe()
+
+            unsubscribe_signal.send_robust(
+                sender=self.__class__, message=self, unsubscribed=False
+            )
 
     def send_response_message(self):
         if self.direction is self.INBOUND:

--- a/django_twilio_sms/models.py
+++ b/django_twilio_sms/models.py
@@ -319,21 +319,22 @@ class Message(Sid):
         return absolute_uri.get_absolute_uri()
 
     def check_for_subscription_message(self):
-        body = self.body.upper().strip()
+        if self.direction is self.INBOUND:
+            body = self.body.upper().strip()
 
-        if body in self.UNSUBSCRIBE_MESSAGES:
-            self.from_phone_number.unsubscribe()
+            if body in self.UNSUBSCRIBE_MESSAGES:
+                self.from_phone_number.unsubscribe()
 
-            unsubscribe_signal.send_robust(
-                sender=self.__class__, message=self, unsubscribed=True
-            )
+                unsubscribe_signal.send_robust(
+                    sender=self.__class__, message=self, unsubscribed=True
+                )
 
-        elif body in self.SUBSCRIBE_MESSAGES:
-            self.from_phone_number.subscribe()
+            elif body in self.SUBSCRIBE_MESSAGES:
+                self.from_phone_number.subscribe()
 
-            unsubscribe_signal.send_robust(
-                sender=self.__class__, message=self, unsubscribed=False
-            )
+                unsubscribe_signal.send_robust(
+                    sender=self.__class__, message=self, unsubscribed=False
+                )
 
     def send_response_message(self):
         if self.direction is self.INBOUND:

--- a/django_twilio_sms/signals.py
+++ b/django_twilio_sms/signals.py
@@ -2,3 +2,6 @@ from django.dispatch import Signal
 
 
 response_message = Signal(providing_args=['action', 'message'])
+
+
+unsubscribe_signal = Signal(providing_args=['message', 'unsubscribed'])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -382,13 +382,18 @@ class MessageModelTest(CommonTestCase):
             'https://www.test.com/twilio-integration/webhooks/callback-view/'
         )
 
-    def test_check_for_subscription_message_if_body_in_unsubscribe(self):
+    @patch('django_twilio_sms.models.unsubscribe_signal')
+    def test_check_for_subscription_message_if_body_in_unsubscribe(
+            self, unsubscribe_signal):
         from_phone_number = phone_number_recipe.make(unsubscribed=False)
         message = message_recipe.make(
             body='STOP', from_phone_number=from_phone_number
         )
         message.check_for_subscription_message()
         self.assertTrue(message.from_phone_number.unsubscribed)
+        unsubscribe_signal.send_robust.assert_called_once_with(
+            sender=Message, message=message, unsubscribed=True
+        )
 
     def test_check_for_subscription_message_if_body_in_subscribe(self):
         from_phone_number = phone_number_recipe.make(unsubscribed=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -489,27 +489,6 @@ class MessageModelTest(CommonTestCase):
         message.sync_twilio_message(self.mock_message(price=None))
         self.assertEqual('0.0', message.price)
 
-    def test_sync_twilio_message_if_direction_equal_inbound(self):
-        phone_number_recipe.make()
-        phone_number_recipe.make(twilio_number=True)
-        message = message_recipe.make()
-        message.sync_twilio_message(self.mock_message())
-        self.assertEqual(
-            PhoneNumber.objects.get(twilio_number=True),
-            message.to_phone_number
-        )
-
-    def test_sync_twilio_message_if_direction_not_equal_inbound(self):
-        phone_number_recipe.make(twilio_number=True)
-        message = message_recipe.make()
-        message.sync_twilio_message(
-            self.mock_message(direction='outbound-api')
-        )
-        self.assertEqual(
-            PhoneNumber.objects.get(twilio_number=True),
-            message.from_phone_number
-        )
-
 
 class ActionModelTest(CommonTestCase):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -235,6 +235,16 @@ class PhoneNumberModelTest(CommonTestCase):
         phone_number = phone_number_recipe.make()
         self.assertEqual('+19999999991', phone_number.as_e164)
 
+    def test_subscribe(self):
+        phone_number = phone_number_recipe.make(unsubscribed=True)
+        phone_number.subscribe()
+        self.assertFalse(phone_number.unsubscribed)
+
+    def test_unsubscribe(self):
+        phone_number = phone_number_recipe.make(unsubscribed=False)
+        phone_number.unsubscribe()
+        self.assertTrue(phone_number.unsubscribed)
+
 
 class MessageModelTest(CommonTestCase):
 


### PR DESCRIPTION
Now tracks unsubscribed `PhoneNumber` to be more in line with [Twilio's standard](https://www.twilio.com/help/faq/sms/does-twilio-support-stop-block-and-cancel-aka-sms-filtering). Checks all inbound messages for subscribe & unsubscribe keywords, updates `PhoneNumber.unsubscribed` accordingly and sends signal `ubsubscribe_signal`.

`Message.send_response_message` now checks `PhoneNumber.unsubscribed` and sends message only when `False`.

Fixes #15 & #16 
